### PR TITLE
Cypress Warning Fix on Github Actions Testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,6 @@ jobs:
         browser: chrome
         headless: true
         start: npm run start:test
-        record: true
-      env:
-        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - run: npm run test:unit
       env:

--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,5 @@
 {
   "baseUrl": "http://127.0.0.1:3030",
   "chromeWebSecurity": false,
-  "projectId": "8uz8g3",
   "video": false
 }


### PR DESCRIPTION
Removes any link to the Cypress Dashboard so this error should no longer appear